### PR TITLE
customap: add support for esp32-c3-devkitc-02 board

### DIFF
--- a/platformio-custom-ap/platformio.ini
+++ b/platformio-custom-ap/platformio.ini
@@ -29,3 +29,7 @@ board = esp32dev
 [env:esp8266]
 platform = espressif8266
 board = esp01
+
+[env:esp32-c3]
+platform = espressif32
+board = esp32-c3-devkitc-02


### PR DESCRIPTION
add support for esp32-c3-devkitc-02 (esp32-c3) to customAP.