### PR TITLE
Update platformio.ini - add sonoff_basic board

### DIFF
--- a/platformio-custom-ap/platformio.ini
+++ b/platformio-custom-ap/platformio.ini
@@ -29,3 +29,7 @@ board = esp32dev
 [env:esp8266]
 platform = espressif8266
 board = esp01
+
+[env:sonoff_basic]
+platform = espressif8266
+board = sonoff_basic


### PR DESCRIPTION
Successfully flashed to a Sonoff S31. Should support more Sonoff devices as well.